### PR TITLE
Upgrade app to .Net 6 and fix to work on Windows 11 Visual Studio 2022

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
-{
-  "sdk": {
-    "version": "6.0.200",
-    "rollForward": "feature"
-  }
-}
+//{
+//  "sdk": {
+//    "version": "6.0.200",
+//    "rollForward": "feature"
+//  }
+//}

--- a/src/IconPacks.Browser/IconPacks.Browser.csproj
+++ b/src/IconPacks.Browser/IconPacks.Browser.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>net47;net5.0-windows</TargetFrameworks>
+        <TargetFrameworks>net47;net6.0-windows</TargetFrameworks>
         <OutputType>WinExe</OutputType>
         <UseWPF>true</UseWPF>
         <AssemblyName>IconPacks.Browser</AssemblyName>


### PR DESCRIPTION
I downloaded the latest version and it wouldn't build or run.
To get it to build, I changed .Net 5 to .Net 6, because .Net 5 is outdated.
The project could not be started due to a version mismatch in the global.json file, I commented out the content to start.